### PR TITLE
Bump Scala munit dotty sbt plugin versions

### DIFF
--- a/week_1/build.sbt
+++ b/week_1/build.sbt
@@ -1,2 +1,2 @@
-scalaVersion := "0.27.0-RC1"
+scalaVersion := "3.0.0-M1"
 libraryDependencies += ("org.creativescala" %% "doodle" % "0.9.21").withDottyCompat(scalaVersion.value)

--- a/week_1/project/plugins.sbt
+++ b/week_1/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")

--- a/week_2/build.sbt
+++ b/week_2/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "0.27.0-RC1"
+scalaVersion := "3.0.0-M1"
 libraryDependencies += ("org.creativescala" %% "doodle" % "0.9.21").withDottyCompat(scalaVersion.value)
 Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / useSuperShell := false

--- a/week_2/project/plugins.sbt
+++ b/week_2/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")

--- a/week_4/build.sbt
+++ b/week_4/build.sbt
@@ -1,12 +1,12 @@
 name := "error-handling"
 
-scalaVersion := "0.27.0-RC1"
+scalaVersion := "3.0.0-M1"
 
 libraryDependencies ++=
   Seq(
     "org.scala-js"   % "scalajs-dom_sjs1_2.13" % "1.1.0",
-    "org.scalameta" %% "munit"                 % "0.7.12" % Test,
-    "org.scalameta" %% "munit-scalacheck"      % "0.7.12" % Test
+    "org.scalameta" %% "munit"                 % "0.7.16" % Test,
+    "org.scalameta" %% "munit-scalacheck"      % "0.7.16" % Test
   )
 
 testFrameworks += new TestFramework("munit.Framework")

--- a/week_4/project/plugins.sbt
+++ b/week_4/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")

--- a/week_5/build.sbt
+++ b/week_5/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "0.27.0-RC1"
+scalaVersion := "3.0.0-M1"

--- a/week_5/project/plugins.sbt
+++ b/week_5/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")

--- a/week_6/build.sbt
+++ b/week_6/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "0.27.0-RC1"
+scalaVersion := "3.0.0-M1"

--- a/week_6/project/plugins.sbt
+++ b/week_6/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")


### PR DESCRIPTION
- Dotty 0.27.0-RC1 -> Scala 3.0.0-M1
- Bumped `sbt-dotty` plugin version
- Bump `munit` version