### PR TITLE
Update to Scala 3.0.0-RC1

### DIFF
--- a/week_1/build.sbt
+++ b/week_1/build.sbt
@@ -1,2 +1,2 @@
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"
 libraryDependencies += ("org.creativescala" %% "doodle" % "0.9.21").withDottyCompat(scalaVersion.value)

--- a/week_1/project/plugins.sbt
+++ b/week_1/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/week_1/src/main/scala/org/epfl/02_houses/Houses.scala
+++ b/week_1/src/main/scala/org/epfl/02_houses/Houses.scala
@@ -1,16 +1,16 @@
 package effective
 
-// import cats.instances.all._
-import doodle.java2d._
-// import doodle.syntax._
-import doodle.effect.Writer._
-// import doodle.examples._
-import doodle.image._
-import doodle.image.syntax._
-// import doodle.image.examples._
-// import doodle.interact.syntax._
-// import doodle.explore.syntax._
-import doodle.core._
+// import cats.instances.all.*
+import doodle.java2d.*
+// import doodle.syntax.*
+import doodle.effect.Writer.*
+// import doodle.examples.*
+import doodle.image.*
+import doodle.image.syntax.*
+// import doodle.image.examples.*
+// import doodle.interact.syntax.*
+// import doodle.explore.syntax.*
+import doodle.core.*
 
 def house1 =
   Image.rectangle(100, 200)

--- a/week_2/build.sbt
+++ b/week_2/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"
 libraryDependencies += ("org.creativescala" %% "doodle" % "0.9.21").withDottyCompat(scalaVersion.value)
 Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / useSuperShell := false

--- a/week_2/project/plugins.sbt
+++ b/week_2/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/week_2/src/main/scala/org/epfl/04_collections/collections.worksheet.sc
+++ b/week_2/src/main/scala/org/epfl/04_collections/collections.worksheet.sc
@@ -40,8 +40,8 @@ val tuple: (Int, String, Boolean) = (42, "foo", true)
 Map("Alice" -> 42, "Bob" -> 30) == Map(("Alice", 42), ("Bob", 30))
 
 // Accessing Tuple elements
-val fortyTwo = tuple._1
-val foo      = tuple._2
+val fortyTwo = tuple(0)
+val foo      = tuple(1)
 
 // Destructured assignment
 val (fortyTwo_, foo_, bool_) = tuple

--- a/week_2/src/main/scala/org/epfl/13_sierpinski/Sierpinski.scala
+++ b/week_2/src/main/scala/org/epfl/13_sierpinski/Sierpinski.scala
@@ -2,9 +2,9 @@ package org.epfl.sierpinski
 
 import doodle.core.Color
 import doodle.image.Image
-import doodle.image.syntax._
-import doodle.java2d._
-import cats.instances.list._
+import doodle.image.syntax.*
+import doodle.java2d.*
+import cats.instances.list.*
 
 // Depth of the Sierpinski triangle
 val iterations = 6

--- a/week_3/build.sbt
+++ b/week_3/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"

--- a/week_3/project/plugins.sbt
+++ b/week_3/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/week_4/build.sbt
+++ b/week_4/build.sbt
@@ -1,12 +1,12 @@
 name := "error-handling"
 
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"
 
 libraryDependencies ++=
   Seq(
     ("org.scala-js" %%% "scalajs-dom" % "1.1.0").withDottyCompat(scalaVersion.value),
-    "org.scalameta" %% "munit"                 % "0.7.20" % Test,
-    "org.scalameta" %% "munit-scalacheck"      % "0.7.20" % Test
+    "org.scalameta" %% "munit"                 % "0.7.22" % Test,
+    "org.scalameta" %% "munit-scalacheck"      % "0.7.22" % Test
   )
 
 testFrameworks += new TestFramework("munit.Framework")

--- a/week_4/project/plugins.sbt
+++ b/week_4/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")

--- a/week_5/build.sbt
+++ b/week_5/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"

--- a/week_5/project/plugins.sbt
+++ b/week_5/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/week_5/src/main/scala/org/epfl/06_conditional_givens/conditional_givens_04_order_tuples.worksheet.sc
+++ b/week_5/src/main/scala/org/epfl/06_conditional_givens/conditional_givens_04_order_tuples.worksheet.sc
@@ -16,11 +16,11 @@ end given
 
 given [A: Ordering, B: Ordering]: Ordering[(A, B)] with
   def compare(t1: (A, B), t2: (A, B)): Int =
-    val c = summon[Ordering[A]].compare(t1._1, t2._1)
+    val c = summon[Ordering[A]].compare(t1(0), t2(0))
     if c != 0 then
       c
     else
-      summon[Ordering[B]].compare(t1._2, t2._2)
+      summon[Ordering[B]].compare(t1(1), t2(1))
 end given
 
 def sort[A](xs: List[A])(using ord: Ordering[A]): List[A] =

--- a/week_6/build.sbt
+++ b/week_6/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "3.0.0-M3"
+scalaVersion := "3.0.0-RC1"

--- a/week_6/project/plugins.sbt
+++ b/week_6/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")

--- a/week_6/src/main/scala/org/epfl/errorhandling/part9/resilientGetAllPages.scala
+++ b/week_6/src/main/scala/org/epfl/errorhandling/part9/resilientGetAllPages.scala
@@ -1,7 +1,7 @@
 package org.epfl.errorhandling.part9
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.ExecutionContext.Implicits.*
 import scala.util.Random
 import scala.util.control.NonFatal
 


### PR DESCRIPTION
- Use new syntax for wildcard imports
- Use Scala 3 syntax for tuple access